### PR TITLE
improved example for nut_upsd_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ NUT Server that will monitor itself with a Cyberpower 1350C UPS:
           nut_upsd_users:
             admin:
               password: password1
-              actions: set
-              actions: fsd
+              actions:
+                - set
+                - fsd
               instcmds: all
             monitor:
               password: password2


### PR DESCRIPTION
Hey,

as pointed out by you in #1 here comes a fix for the example of `nut_upsd_users` in the readme.md. I've tested I and gained:

```
# cat /etc/nut/upsd.users 
## File managed by Ansible!
[admin]
  password = password1
  actions = set
  actions = fsd
  instcmds = all
```
